### PR TITLE
Trivial: Remove dollar prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ described in detail below.
 Clone the `tensorflow-hangul-recognition` locally. In a terminal, run:
 
 ```
-$ git clone https://github.com/IBM/tensorflow-hangul-recognition
+git clone https://github.com/IBM/tensorflow-hangul-recognition
 ```
 
 ### 2. Install Prerequisites


### PR DESCRIPTION
Make the clone example consistent w/ the other code boxes that don't show output.