### PR TITLE
just python

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Optionally, to isolate your runtime environment, use a virtual environment as de
 [here](https://packaging.python.org/guides/installing-using-pip-and-virtualenv/).
 Create a virtual environment:
 ```
-python3 -m pip install --user virtualenv
-python3 -m virtualenv .venv
+python -m pip install --user virtualenv
+python -m virtualenv .venv
 source .venv/bin/activate
 ```
 


### PR DESCRIPTION
Changed python3 to python in the new venv examples.
Verified that it all runs with python2.7 or python3.6
So... probably no need to mention versions and the python3 examples are just confusing.