### PR TITLE
Remove numpy from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-numpy>=1.12.1
+# NOTE(pvaneck): tensorflow requires a lower version of numpy than the latest, so just use the
+# version that tensorflow wants by removing the numpy dependency in this file.
+#numpy>=1.12.1
+tensorflow>=1.7.0
 Pillow>=4.1.1
 scipy>=0.18.1
-tensorflow>=1.7.0


### PR DESCRIPTION
Explicitly declaring numpy in the requirements.txt file can cause incompatibility issues when
installing dependencies. This seems to be an issue with how pip resolves dependencies declared
multiple times. We should just use the numpy version that tensorflow wants by listing tensorflow
first in the requirements file.

When running with the latest TF, I hit:
`tensorflow 1.10.0 has requirement numpy<=1.14.5,>=1.13.3, but you'll have numpy 1.15.0 which is incompatible.`

This PR resolves this.