### PR TITLE
Closing the InteractiveSession opened at Line 64

### DIFF
--- a/tools/classify-hangul.py
+++ b/tools/classify-hangul.py
@@ -63,7 +63,7 @@ def classify(args):
     image = read_image(args.image)
     sess = tf.InteractiveSession()
     image_array = sess.run(image)
-
+    sess.close()
     with tf.Session(graph=graph) as graph_sess:
         predictions = graph_sess.run(y, feed_dict={x: image_array,
                                                    keep_prob: 1.0})


### PR DESCRIPTION
The ```InteractiveSession``` started at Line 64 is never closed. This pull request closes the ```InteractiveSession``` at Line 66 as the sess variable is no longer used after that