### PR TITLE
Use tf.data for input data pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,11 @@ Install the Python requirements for this code pattern. Run:
 pip install -r requirements.txt
 ```
 
-> **TIP** :bulb: To terminate the virtual environment use the `deactivate` command.
+> **Note**: If you have an Nvidia GPU and want to use it in training, then you will need to
+install `tensorflow-gpu` instead of `tensorflow`. Details for installation can be found
+[here](https://www.tensorflow.org/install/gpu).
 
-**Note:** For Windows users, the _scipy_ package is not installable via **pip**.
-The recommended way to use _scipy_ is to install a
-[scientific Python distribution](https://www.scipy.org/install.html#scientific-python-distributions).
-One of the more popular ones is [Anaconda](https://www.anaconda.com/download/).
-However, you can also manually install the _scipy_ package on Windows using one
-of the installers located [here](https://www.lfd.uci.edu/~gohlke/pythonlibs/#scipy).
+> **TIP** :bulb: To terminate the virtual environment use the `deactivate` command.
 
 ### 3. Generate Image Data
 
@@ -251,19 +248,15 @@ Optional flags for this script are:
   Default is _./tfrecords-output_.
 * `--output-dir` for specifying the output directory to store model checkpoints,
    graphs, and Protocol Buffer files. Default is _./saved-model_.
-* `--num-train-steps` for specifying the number of training steps to perform.
-  This should be increased with more data (or vice versa). The number of steps
-  should cover several iterations over all of the training data (epochs).
-  For example, if I had 320,000 images in my training set, one epoch would be
-  _320000/100 = 3200_ steps where _100_ is the default batch size. So, if I wanted
-  to train for 30 epochs, I would simply do _3200*30 = 96000_ training steps.
-  Definitely tune this parameter on your own to try and hit at least 15 epochs.
-  Default is _30000_ steps.
+* `--num-train-epochs` for specifying the number of epochs to train for.
+  This is the number of complete passes through the training dataset.
+  Definitely try tuning this parameter to improve model performance on your dataset.
+  Default is 15 epochs.
 
 To run the training, simply do the following from the root of the project:
 
 ```
-python ./hangul_model.py --label-file <your label file path> --num-train-steps <num>
+python ./hangul_model.py --label-file <your label file path> --num-train-epochs <num>
 ```
 
 Depending on how many images you have, this will likely take a long time to

--- a/hangul-tensordroid/app/src/main/res/values/translate_api.xml
+++ b/hangul-tensordroid/app/src/main/res/values/translate_api.xml
@@ -1,5 +1,5 @@
 <resources>
-    <!-- The username and password provided by the Watson Language Translator service. -->
+    <!-- The apikey and url provided by the Watson Language Translator service. -->
     <string name="apikey"></string>
     <string name="url"></string>
 </resources>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # NOTE(pvaneck): tensorflow requires a lower version of numpy than the latest, so just use the
 # version that tensorflow wants by removing the numpy dependency in this file.
 #numpy>=1.12.1
-tensorflow>=1.7.0
+tensorflow>=1.13.0,<2
 Pillow>=4.1.1
 scipy>=0.18.1

--- a/tools/convert-to-tfrecords.py
+++ b/tools/convert-to-tfrecords.py
@@ -90,7 +90,7 @@ class TFRecordsConverter(object):
         for i in indices:
             filename = self.filenames[i]
             label = self.labels[i]
-            with tf.gfile.FastGFile(filename, 'rb') as f:
+            with tf.gfile.GFile(filename, 'rb') as f:
                 im_data = f.read()
 
             # Example is a data format that contains a key-value store, where


### PR DESCRIPTION
Using tf.data speeds up training performance, so the model script now uses this which should get rid of several of the deprecation warnings.

This PR also:
* Fixes some misc deprecation warnings in other areas.
* Make sure we only download TF < 2.0 for now as TF 2.0 has some pretty big API changes.
* Changes --num-train-steps param in hangul_model.py to --num-train-epochs. Epochs denotes more clearly how much you are training a model. The use of epochs also falls more in line with the tf.data input pipeline.
* Remove the Windows scipy note from the README as Windows scipy packages are now provided on PyPI.

I've tested full data generation and training on my Mac OS and Windows 10 with GPU for the 256 character label file. I will probably try testing the full 2350 character label file soon.

Closes: #47 