### PR TITLE
Pin TF version

### DIFF
--- a/hangul-tensordroid/app/build.gradle
+++ b/hangul-tensordroid/app/build.gradle
@@ -27,5 +27,5 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:26.+'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     testImplementation 'junit:junit:4.12'
-    implementation 'org.tensorflow:tensorflow-android:+'
+    implementation 'org.tensorflow:tensorflow-android:1.13.1'
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # NOTE(pvaneck): tensorflow requires a lower version of numpy than the latest, so just use the
 # version that tensorflow wants by removing the numpy dependency in this file.
 #numpy>=1.12.1
-tensorflow>=1.13.0,<2
+tensorflow==1.13.1
 Pillow>=4.1.1
 scipy>=0.18.1


### PR DESCRIPTION
Higher versions causing issues with the highest available TensorFlow AAR. Will pin the version until I can get this updated for TF 2+ and TF Lite.